### PR TITLE
Minor fixes for ADI in Visual Studio project files

### DIFF
--- a/modules/aerodyn/src/AeroDyn_Inflow_C_Binding.f90
+++ b/modules/aerodyn/src/AeroDyn_Inflow_C_Binding.f90
@@ -29,6 +29,7 @@ MODULE AeroDyn_Inflow_C_BINDING
 
  
    IMPLICIT NONE
+   SAVE
 
    PUBLIC :: AeroDyn_Inflow_C_Init
    !PUBLIC :: AeroDyn_Inflow_C_ReInit

--- a/vs-build/AeroDyn/AeroDyn_Driver.vfproj
+++ b/vs-build/AeroDyn/AeroDyn_Driver.vfproj
@@ -110,7 +110,7 @@
 		<Filter Name="Source Files" Filter="f90;for;f;fpp;ftn;def;odl;idl">
 		<Filter Name="ADI">
 		<Filter Name="RegistryFiles">
-		<File RelativePath="..\..\modules\AeroDyn\src\AeroDyn_Inflow.f90">
+		<File RelativePath="..\..\modules\AeroDyn\src\AeroDyn_Inflow_Registry.txt">
 			<FileConfiguration Name="Debug_Double|Win32">
 				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ADI" Description="Running Registry for ADI" Outputs="..\..\modules\AeroDyn\src\AeroDyn_Inflow_Types.f90"/></FileConfiguration>
 			<FileConfiguration Name="Release_OpenMP|x64">

--- a/vs-build/AeroDyn_Inflow_c_binding/AeroDyn_Inflow_c_binding.vfproj
+++ b/vs-build/AeroDyn_Inflow_c_binding/AeroDyn_Inflow_c_binding.vfproj
@@ -130,7 +130,7 @@
 		<Filter Name="Source Files" Filter="f90;for;f;fpp;ftn;def;odl;idl">
 		<Filter Name="ADI">
 		<Filter Name="RegistryFiles">
-		<File RelativePath="..\..\modules\AeroDyn\src\AeroDyn_Inflow.f90">
+		<File RelativePath="..\..\modules\AeroDyn\src\AeroDyn_Inflow_Registry.txt">
 			<FileConfiguration Name="Debug_Double|Win32">
 				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ADI" Description="Running Registry for ADI" Outputs="..\..\modules\AeroDyn\src\AeroDyn_Inflow_Types.f90"/></FileConfiguration>
 			<FileConfiguration Name="Release_OpenMP_Double|Win32">


### PR DESCRIPTION
- fix file name for AeroDyn_Inflow_Registry.txt in the visual studio project files
- also add `SAVE` attribute to avoid compiler warnings
